### PR TITLE
Add WXT Solana wallet pages

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,11 @@
-# WXT + React
+# MetaPro Solana Wallet Extension
 
-This template should help get you started developing with React in WXT.
+This extension is built with [WXT](https://wxt.dev) and React. It includes a
+simple Solana wallet using the `@solana/wallet-adapter` libraries. Two pages are
+available:
+
+- **/login** – Connect your Solana wallet.
+- **/index** – Displays basic wallet information once connected.
+
+Run `npm run dev` inside the `extension` directory to start developing the
+extension.

--- a/extension/entrypoints/index/App.tsx
+++ b/extension/entrypoints/index/App.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ConnectionProvider, WalletProvider, useWallet } from '@solana/wallet-adapter-react';
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
+import { WalletModalProvider, WalletMultiButton } from '@solana/wallet-adapter-react-ui';
+import { clusterApiUrl } from '@solana/web3.js';
+import '@solana/wallet-adapter-react-ui/styles.css';
+
+function WalletInfo() {
+  const { publicKey } = useWallet();
+  if (!publicKey) return <p>Please connect your wallet.</p>;
+  return <p>Connected wallet: {publicKey.toBase58()}</p>;
+}
+
+export default function App() {
+  const network = WalletAdapterNetwork.Devnet;
+  const endpoint = clusterApiUrl(network);
+  const wallets = [new PhantomWalletAdapter()];
+
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>
+          <div className="index-container">
+            <h1>MetaPro Solana Wallet</h1>
+            <WalletMultiButton />
+            <WalletInfo />
+          </div>
+        </WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+}

--- a/extension/entrypoints/index/index.html
+++ b/extension/entrypoints/index/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MetaPro Wallet</title>
+    <meta name="manifest.type" content="page" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/entrypoints/index/main.tsx
+++ b/extension/entrypoints/index/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/extension/entrypoints/index/style.css
+++ b/extension/entrypoints/index/style.css
@@ -1,0 +1,11 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+  background: #fff;
+}
+.index-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}

--- a/extension/entrypoints/login/App.tsx
+++ b/extension/entrypoints/login/App.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
+import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
+import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
+import { WalletModalProvider, WalletMultiButton } from '@solana/wallet-adapter-react-ui';
+import { clusterApiUrl } from '@solana/web3.js';
+import '@solana/wallet-adapter-react-ui/styles.css';
+
+export default function App() {
+  const network = WalletAdapterNetwork.Devnet;
+  const endpoint = clusterApiUrl(network);
+  const wallets = [new PhantomWalletAdapter()];
+
+  return (
+    <ConnectionProvider endpoint={endpoint}>
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>
+          <div className="login-container">
+            <h1>MetaPro Wallet Login</h1>
+            <WalletMultiButton />
+          </div>
+        </WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+}

--- a/extension/entrypoints/login/index.html
+++ b/extension/entrypoints/login/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MetaPro Wallet Login</title>
+    <meta name="manifest.type" content="page" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/entrypoints/login/main.tsx
+++ b/extension/entrypoints/login/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/extension/entrypoints/login/style.css
+++ b/extension/entrypoints/login/style.css
@@ -1,0 +1,11 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+  background: #fafafa;
+}
+.login-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -16,7 +16,12 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@solana/web3.js": "^1.95.0",
+    "@solana/wallet-adapter-base": "^0.18.0",
+    "@solana/wallet-adapter-react": "^0.18.0",
+    "@solana/wallet-adapter-react-ui": "^0.18.0",
+    "@solana/wallet-adapter-wallets": "^0.18.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.2",


### PR DESCRIPTION
## Summary
- add React Solana wallet pages (`/login` and `/index`) in `extension`
- update README for new wallet pages
- include Solana wallet adapter dependencies

## Testing
- `npm run compile` *(fails: Cannot read file '/workspace/MetaPro/extension/.wxt/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_684199be03fc8321aed196a45b32de61